### PR TITLE
ci: add python 3.11 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,47 +4,36 @@ orbs:
   flake8: arrai/flake8@11.0.1
 executors:
   python27:
-    environment:
-        LANG: C.UTF-8
     docker:
      - image: cimg/python:2.7
   python35:
-    environment:
-        LANG: C.UTF-8
     docker:
      - image: cimg/python:3.5
   python36:
-    environment:
-        LANG: C.UTF-8
     docker:
      - image: cimg/python:3.6
   python37:
-    environment:
-        LANG: C.UTF-8
     docker:
      - image: cimg/python:3.7
   python38:
-    environment:
-        LANG: C.UTF-8
     docker:
      - image: cimg/python:3.8
   python39:
-    environment:
-        LANG: C.UTF-8
     docker:
      - image: cimg/python:3.9
   python310:
-    environment:
-        LANG: C.UTF-8
     docker:
      - image: cimg/python:3.10
+  python311:
+    docker:
+     - image: cimg/python:3.11
 jobs:
   pythontests:
     parameters:
       executor:
         description: "Execution environment for the test job."
         type: executor
-        default: python37
+        default: python311
     executor: <<parameters.executor>>
     steps:
       - checkout
@@ -133,6 +122,10 @@ workflows:
           name: python310
           context: arrai-global
           executor: python310
+      - pythontests:
+          name: python311
+          context: arrai-global
+          executor: python311
       - flake8/flake8:
           name: flake8
           context: arrai-global

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ A [`formatter_class` for `argparse`](https://docs.python.org/3/library/argparse.
 
 ![Tests](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/python310.svg) [![Coverage](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/python310.coverage.svg)](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/htmlcov_python310/)
 
-![Tests](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/python310.svg) [![Coverage](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/python310.coverage.svg)](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/htmlcov_python310/)
-
 ![Tests](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/python39.svg) [![Coverage](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/python39.coverage.svg)](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/htmlcov_python39/)
 
 ![Tests](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/python38.svg) [![Coverage](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/python38.coverage.svg)](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/htmlcov_python38/)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ A [`formatter_class` for `argparse`](https://docs.python.org/3/library/argparse.
 
 [![PYPI](https://img.shields.io/pypi/v/argparse-color-formatter?style=for-the-badge)](https://pypi.org/project/argparse-color-formatter/)
 
+![Tests](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/python311.svg) [![Coverage](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/python311.coverage.svg)](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/htmlcov_python311/)
+
+![Tests](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/python310.svg) [![Coverage](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/python310.coverage.svg)](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/htmlcov_python310/)
+
 ![Tests](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/python310.svg) [![Coverage](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/python310.coverage.svg)](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/htmlcov_python310/)
 
 ![Tests](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/python39.svg) [![Coverage](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/python39.coverage.svg)](https://docs.arrai-dev.com/argparse-color-formatter/artifacts/main/htmlcov_python39/)

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'License :: OSI Approved :: BSD License',
         'Environment :: Console',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Python 3.11 is out of RC so we should run tests against it.