### PR TITLE
feat: support Python 3.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ executors:
     python313:
         docker:
             - image: cimg/python:3.13
+    python314:
+        docker:
+            - image: cimg/python:3.14
 jobs:
     build:
         executor: python312
@@ -200,6 +203,18 @@ workflows:
                               - main
                       tags:
                           ignore: /.*/
+            - tests:
+                  name: python314
+                  context: arrai-global
+                  executor: python314
+                  version: "3.14"
+                  publish_artifacts: true
+                  filters:
+                      branches:
+                          only:
+                              - main
+                      tags:
+                          ignore: /.*/
             # Other branches and tags run the same tests without credentials.
             - tests:
                 name: python39-no-badge
@@ -251,6 +266,16 @@ workflows:
                               - main
                       tags:
                           only: /.*/
+            - tests:
+                  name: python314-no-badge
+                  executor: python314
+                  version: "3.14"
+                  filters:
+                      branches:
+                          ignore:
+                              - main
+                      tags:
+                          only: /.*/
             - build:
                 name: build
                 requires:
@@ -259,11 +284,13 @@ workflows:
                     - python311
                     - python312
                     - python313
+                    - python314
                     - python39-no-badge
                     - python310-no-badge
                     - python311-no-badge
                     - python312-no-badge
                     - python313-no-badge
+                    - python314-no-badge
                 filters:
                     branches:
                         only: /.*/
@@ -319,6 +346,16 @@ workflows:
                           only: /.*/
                       tags:
                           only: /.*/
+            - install:
+                  name: python314_install
+                  executor: python314
+                  requires:
+                      - build
+                  filters:
+                      branches:
+                          only: /.*/
+                      tags:
+                          only: /.*/
             - github/create_release:
                 name: release_on_github
                 context: arrai-global
@@ -328,6 +365,7 @@ workflows:
                     - python311_install
                     - python312_install
                     - python313_install
+                    - python314_install
                 filters:
                     tags:
                         only: /.*/
@@ -344,6 +382,7 @@ workflows:
                     - python311_install
                     - python312_install
                     - python313_install
+                    - python314_install
                 filters:
                     tags:
                         only: /.*/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # argparse-color-formatter
-A [`formatter_class` for `argparse`](https://docs.python.org/3/library/argparse.html#formatter-class) that deals with ANSI colour escapes. Specifically, this formatter does not count escape characters as displayed characters when wrapping argparse's help text into the terminal.
+
+An ANSI-aware [`formatter_class` for `argparse`](https://docs.python.org/3/library/argparse.html#formatter-class).
+It calculates layout using the visible width of help text, without counting ANSI
+escape sequences as displayed characters.
 
 ![That script's help text is so cool...](https://docs.arrai.dev/argparse-color-formatter/readme/acf.png "That script's help text is so cool...")
 
@@ -25,16 +28,60 @@ A [`formatter_class` for `argparse`](https://docs.python.org/3/library/argparse.
 $ pip install argparse-color-formatter
 ```
 
+## What it does
+
+This package does not decide which text to colour. Your application supplies the
+ANSI-coloured program names, metavars, descriptions, help strings, or epilogues.
+`ColorHelpFormatter` then:
+
+- wraps descriptions, help strings, and usage text at their visible width;
+- aligns option and positional argument labels correctly; and
+- preserves ANSI sequences in the formatted output.
+
+Without an ANSI-aware formatter, invisible escape sequences can make `argparse`
+wrap text too early or misalign help columns.
+
+## Do I need this on Python 3.14?
+
+Python 3.14 added [native colour support to `argparse`](https://docs.python.org/3.14/library/argparse.html#color).
+If you only want the standard `argparse` colour theme, you do not need this
+package.
+
+This package is still useful when your application embeds its own ANSI sequences
+in descriptions, help strings, program names, or metavars. Python 3.14 accounts
+for its own theme in some layout calculations, but still wraps arbitrary
+application-coloured descriptions and help strings using their encoded length.
+`ColorHelpFormatter` handles those sequences by their visible width and preserves
+the native Python 3.14 theme alongside them.
+
+## Python 3.9 to 3.13
+
+These Python versions do not add colours to `argparse` help. Use a library such
+as [`ansicolors`](https://pypi.org/project/ansicolors/) or generate ANSI
+sequences directly, then use `ColorHelpFormatter` to keep the resulting output
+aligned and wrapped correctly.
+
 ## Usage
 
-Pass in `argparse_color_formatter.ColorHelpFormatter` to a new argument parser as `formatter_class`
+Pass `ColorHelpFormatter` to an argument parser as `formatter_class`. The example
+uses `ansicolors`, which is installed as a dependency of this package.
 
 ```python
 import argparse
+
+from colors import bold
+
 from argparse_color_formatter import ColorHelpFormatter
 
+output = bold("FILE")
 parser = argparse.ArgumentParser(
-    formatter_class=ColorHelpFormatter
+    description=f"Write the generated report to {output}.",
+    formatter_class=ColorHelpFormatter,
+)
+parser.add_argument(
+    "--output",
+    metavar=output,
+    help=f"save the report as {output}",
 )
 ```
 
@@ -60,9 +107,12 @@ pipenv run build
 pipenv run test
 ```
 
-## After & Before
-ANSI colour escapes using this library's new `ColorHelpFormatter`:
+## After and before
+
+ANSI colour escapes using this library's `ColorHelpFormatter`:
+
 ![after screenshot](https://docs.arrai.dev/argparse-color-formatter/readme/after.png)
 
 ANSI colour escapes using the default `HelpFormatter`:
+
 ![before screenshot](https://docs.arrai.dev/argparse-color-formatter/readme/before.png)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A [`formatter_class` for `argparse`](https://docs.python.org/3/library/argparse.
 
 [![PYPI](https://img.shields.io/pypi/v/argparse-color-formatter?style=for-the-badge)](https://pypi.org/project/argparse-color-formatter/)
 
+![Tests](https://docs.arrai.dev/argparse-color-formatter/artifacts/main/python314.svg) [![Coverage](https://docs.arrai.dev/argparse-color-formatter/artifacts/main/python314.coverage.svg)](https://docs.arrai.dev/argparse-color-formatter/artifacts/main/htmlcov_python314/)
+
 ![Tests](https://docs.arrai.dev/argparse-color-formatter/artifacts/main/python313.svg) [![Coverage](https://docs.arrai.dev/argparse-color-formatter/artifacts/main/python313.coverage.svg)](https://docs.arrai.dev/argparse-color-formatter/artifacts/main/htmlcov_python313/)
 
 ![Tests](https://docs.arrai.dev/argparse-color-formatter/artifacts/main/python312.svg) [![Coverage](https://docs.arrai.dev/argparse-color-formatter/artifacts/main/python312.coverage.svg)](https://docs.arrai.dev/argparse-color-formatter/artifacts/main/htmlcov_python312/)

--- a/argparse_color_formatter.py
+++ b/argparse_color_formatter.py
@@ -150,11 +150,12 @@ class ColorHelpFormatterMixin(object):
         elif usage is None:
             prog = "%(prog)s" % {"prog": self._prog}
 
-            # Python 3.14 replaced _format_actions_usage with
-            # _get_actions_usage_parts.
-            get_usage_parts = getattr(self, "_get_actions_usage_parts", None)
-            if get_usage_parts is not None:
-                parts, pos_start = get_usage_parts(actions, groups)
+            # Python 3.14 removed _format_actions_usage and changed the
+            # return value of _get_actions_usage_parts. Python 3.13 exposes
+            # both methods, including the older return value.
+            compose = getattr(self, "_format_actions_usage", None)
+            if compose is None:
+                parts, pos_start = self._get_actions_usage_parts(actions, groups)
                 opt_parts = parts[:pos_start]
                 pos_parts = parts[pos_start:]
                 action_usage = " ".join(parts)
@@ -168,7 +169,6 @@ class ColorHelpFormatterMixin(object):
                     else:
                         positionals.append(action)
 
-                compose = self._format_actions_usage
                 action_usage = compose(optionals + positionals, groups)
 
             usage = " ".join([s for s in [prog, action_usage] if s])
@@ -177,7 +177,7 @@ class ColorHelpFormatterMixin(object):
             text_width = self._width - self._current_indent
             if prefix_len + len(strip_color(usage)) > text_width:
 
-                if get_usage_parts is None:
+                if compose is not None:
                     # break usage into wrappable parts
                     part_regexp = (
                         r'\(.*?\)+(?=\s|$)|'

--- a/argparse_color_formatter.py
+++ b/argparse_color_formatter.py
@@ -121,52 +121,75 @@ class ColorHelpFormatterMixin(object):
     # modified upstream code, not going to refactor for complexity.
     # fmt: off
     def _format_usage(self, usage, actions, groups, prefix):  # noqa: C901
+        theme = getattr(self, "_theme", None)
+
         if prefix is None:
             prefix = _("usage: ")
         prefix_len = len(strip_color(prefix))
 
         # if usage is specified, use that
         if usage is not None:
-            usage = usage % {"prog": self._prog}
+            if theme is None:
+                usage = usage % {"prog": self._prog}
+            else:
+                usage = (
+                    theme.prog_extra
+                    + usage
+                    % {"prog": f"{theme.prog}{self._prog}{theme.reset}{theme.prog_extra}"}
+                    + theme.reset
+                )
 
         # if no optionals or positionals are available, usage is just prog
         elif usage is None and not actions:
-            usage = "%(prog)s" % {"prog": self._prog}
+            if theme is None:
+                usage = "%(prog)s" % {"prog": self._prog}
+            else:
+                usage = f"{theme.prog}{self._prog}{theme.reset}"
 
         # if optionals and positionals are available, calculate usage
         elif usage is None:
             prog = "%(prog)s" % {"prog": self._prog}
 
-            # split optionals from positionals
-            optionals = []
-            positionals = []
-            for action in actions:
-                if action.option_strings:
-                    optionals.append(action)
-                else:
-                    positionals.append(action)
+            # Python 3.14 replaced _format_actions_usage with
+            # _get_actions_usage_parts.
+            get_usage_parts = getattr(self, "_get_actions_usage_parts", None)
+            if get_usage_parts is not None:
+                parts, pos_start = get_usage_parts(actions, groups)
+                opt_parts = parts[:pos_start]
+                pos_parts = parts[pos_start:]
+                action_usage = " ".join(parts)
+            else:
+                # split optionals from positionals
+                optionals = []
+                positionals = []
+                for action in actions:
+                    if action.option_strings:
+                        optionals.append(action)
+                    else:
+                        positionals.append(action)
 
-            # build full usage string
-            compose = self._format_actions_usage
-            action_usage = compose(optionals + positionals, groups)
+                compose = self._format_actions_usage
+                action_usage = compose(optionals + positionals, groups)
+
             usage = " ".join([s for s in [prog, action_usage] if s])
 
             # wrap the usage parts if it's too long
             text_width = self._width - self._current_indent
             if prefix_len + len(strip_color(usage)) > text_width:
 
-                # break usage into wrappable parts
-                part_regexp = (
-                    r'\(.*?\)+(?=\s|$)|'
-                    r'\[.*?\]+(?=\s|$)|'
-                    r'\S+'
-                )
-                opt_usage = compose(optionals, groups)
-                pos_usage = compose(positionals, groups)
-                opt_parts = _re.findall(part_regexp, opt_usage)
-                pos_parts = _re.findall(part_regexp, pos_usage)
-                assert " ".join(opt_parts) == opt_usage
-                assert " ".join(pos_parts) == pos_usage
+                if get_usage_parts is None:
+                    # break usage into wrappable parts
+                    part_regexp = (
+                        r'\(.*?\)+(?=\s|$)|'
+                        r'\[.*?\]+(?=\s|$)|'
+                        r'\S+'
+                    )
+                    opt_usage = compose(optionals, groups)
+                    pos_usage = compose(positionals, groups)
+                    opt_parts = _re.findall(part_regexp, opt_usage)
+                    pos_parts = _re.findall(part_regexp, pos_usage)
+                    assert " ".join(opt_parts) == opt_usage
+                    assert " ".join(pos_parts) == pos_usage
 
                 # helper for wrapping lines
                 def get_lines(parts, indent, prefix=None):
@@ -217,8 +240,14 @@ class ColorHelpFormatterMixin(object):
                 # join lines into usage
                 usage = "\n".join(lines)
 
+            if theme is not None:
+                usage = usage.removeprefix(prog)
+                usage = f"{theme.prog}{prog}{theme.reset}{usage}"
+
         # prefix with 'usage:'
-        return "%s%s\n\n" % (prefix, usage)
+        if theme is None:
+            return "%s%s\n\n" % (prefix, usage)
+        return f"{theme.usage}{prefix}{theme.reset}{usage}\n\n"
 
 
 # fmt: on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Environment :: Console",
     "Intended Audience :: Developers",
 ]

--- a/tests.py
+++ b/tests.py
@@ -7,9 +7,11 @@ from collections import OrderedDict
 from functools import partial
 from io import StringIO
 from unittest import TestCase
+from unittest import skipUnless
 
 from colors import bold
 from colors import color
+from colors import strip_color
 from colors import underline
 
 from argparse_color_formatter import ColorHelpFormatter
@@ -493,7 +495,7 @@ class TestColorArgsParserOutput(TestCase):
         out.seek(0)
         self.assertEqual(
             out.read(),
-            "usage: {rainbow_maker}\n" "{rainbow_maker}: error: unrecognized arguments: --bad\n".format(**color_kwargs),
+            "usage: {rainbow_maker}\n{rainbow_maker}: error: unrecognized arguments: --bad\n".format(**color_kwargs),
         )
 
     def test_color_output_with_long_help(self):
@@ -568,6 +570,50 @@ class TestColorArgsParserOutput(TestCase):
             )
         finally:
             del os.environ["COLUMNS"]
+
+    @skipUnless(sys.version_info >= (3, 14), "argparse added native colors in Python 3.14")
+    def test_python314_native_colors_and_application_colors_wrap_correctly(self):
+        old_columns = os.environ.get("COLUMNS")
+        old_python_colors = os.environ.get("PYTHON_COLORS")
+        try:
+            os.environ["COLUMNS"] = "32"
+            os.environ["PYTHON_COLORS"] = "1"
+            colored_word = color("ABCDEFGHIJ", fg="red")
+            parser = argparse.ArgumentParser(
+                prog="rainbow-tool",
+                description=f"prefix {colored_word} suffix words that should wrap cleanly",
+                formatter_class=ColorHelpFormatter,
+            )
+            parser.add_argument(
+                "--example",
+                metavar=colored_word,
+                help=f"prefix {colored_word} suffix words that should wrap cleanly",
+            )
+
+            output = parser.format_help()
+            self.assertIn("\x1b[", output)
+            plain_output = strip_color(output)
+            self.assertIn(
+                "usage: rainbow-tool [-h]\n                    [--example ABCDEFGHIJ]\n",
+                plain_output,
+            )
+            self.assertIn(
+                "prefix ABCDEFGHIJ suffix words\nthat should wrap cleanly\n",
+                plain_output,
+            )
+            self.assertIn(
+                "          prefix ABCDEFGHIJ\n          suffix words that\n          should wrap cleanly\n",
+                plain_output,
+            )
+        finally:
+            if old_columns is None:
+                del os.environ["COLUMNS"]
+            else:
+                os.environ["COLUMNS"] = old_columns
+            if old_python_colors is None:
+                del os.environ["PYTHON_COLORS"]
+            else:
+                os.environ["PYTHON_COLORS"] = old_python_colors
 
 
 class TestColorTextWrapper(TestCase):


### PR DESCRIPTION
## Reviewer brief

This adds Python 3.14 support while preserving Python 3.9 to 3.13 behavior.

### What changed

- Adapts usage formatting to Python 3.14 replacing the private `_format_actions_usage()` API.
- Preserves Python 3.14 native argparse colors alongside application-provided ANSI sequences.
- Adds a focused mixed native and application color wrapping test.
- Extends the CircleCI test and wheel-install matrix, package classifier, and README badges through Python 3.14.
- Clarifies when this ANSI-aware formatter is still useful now that Python 3.14 provides a native argparse theme.

### Review focus

The compatibility check deliberately tests for the removal of `_format_actions_usage()`. Python 3.13.14 backported `_get_actions_usage_parts()`, but its return contract differs from Python 3.14. Checking only for the newer method caused the original Python 3.13 CI failure.

The main behavior to review is usage wrapping when native argparse theme codes and application-supplied ANSI codes appear together.

### Validation

- All 17 tests pass on Python 3.9, 3.12, 3.13.14, and 3.14.6.
- The CircleCI matrix covers tests and built-wheel installation on Python 3.9 to 3.14.
- Ruff lint, formatting, CircleCI configuration validation, wheel build, and isolated Python 3.14 installation pass.